### PR TITLE
python-engineio 4.13.0 (py314 rebuild)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "4.13.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -10,16 +10,16 @@ source:
   sha256: 7375254e85cef1e78559f4ed01f7cfba85a30d0a34d3695f0d96e5e9e73de92d
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<38]
+  skip: true  # [py<38]
 
 requirements:
   host:
-    - python
     - pip
-    - setuptools >=61.2
+    - python
     - wheel
+    - setuptools >=61.2
   run:
     - python
     - simple-websocket >=0.10.0


### PR DESCRIPTION
python-engineio 4.13.0

**Destination channel:**  defaults

### Links

- [PKG-15212](https://anaconda.atlassian.net/browse/PKG-15212) 

### Explanation of changes:

- rebuild for py314


[PKG-15212]: https://anaconda.atlassian.net/browse/PKG-15212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ